### PR TITLE
Update flow for python3.11 and add tox so that docs can be generated

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,10 @@ localinstall:
 	python setup.py install --home=${HOME}
 
 docs:
-	tox -e docs html
+	tox -e docs -- html
 
 livedocs:
-	tox -e docs livehtml
+	tox -e docs -- livehtml
 
 dist:
 	rm -rf MANIFEST 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -246,4 +246,4 @@ texinfo_documents = [
 # texinfo_show_urls = 'footnote'
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'http://docs.python.org/': None}
+intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pytest
 pytest-xdist
 pyflakes
 black
+tox

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ deps = pytest-xdist
 commands = py.test --basetemp={envtmpdir} {posargs}
 
 [testenv:docs]
-whitelist_externals = make
+allowlist_externals = make
 changedir = doc
-deps = sphinx-autobuild
+deps = sphinx
 commands = make []


### PR DESCRIPTION
Here are the updates required to build docs (https://docs.myhdl.org) from make

`make docs`

or

`make livedocs`

I don't know where it goes, but this should work under python 3.11 now.  Also you need to have tox installed on your system to run

`pip install tox`